### PR TITLE
Docker container ruby versionを2.3.1から2.5.1に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
-FROM ruby:2.3.1
+FROM ruby:2.5.1
 ENV LANG C.UTF-8
 
-RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list &&\
-    apt-get update -qq &&\
-    apt-get install -y build-essential libpq-dev nodejs graphviz
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN apt-get install -y mecab libmecab-dev mecab-ipadic mecab-ipadic-utf8
+
+# Install node.js
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install nodejs
+
+# Install yarn
+RUN apt-get update && apt-get install -y curl apt-transport-https wget && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
+
 RUN ["apt-get", "update"]
 RUN ["apt-get", "install", "-y", "vim"]
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.3.1'
+ruby '2.5.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.1'
@@ -77,7 +77,7 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 #hamlの導入
-gem 'haml-rails'
+gem 'haml-rails', '1.0.0'
 gem 'erb2haml'
 gem 'font-awesome-rails'
 gem 'carrierwave'


### PR DESCRIPTION
## チェックポイント

- [x] 開発環境で動作を確認した。
- [x] わかりにくいと思われる箇所にコメントを書いた。

## issue番号

 #53

## 概要

Rubygemの古いバージョンの非対応が目立つため、
コンテナのRuby versionを 2.3.1 から 2.5.1 に変更
(バージョンを上げることで使用しているgemも新しいバージョンを使用することができるため。)

## UI変更点

特になし

## 実装内容

Dockerfile
コンテナを ruby:2.5.1 に変更
Dockerfile内のリファクタリング
```
RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
RUN apt-get install -y mecab libmecab-dev mecab-ipadic mecab-ipadic-utf8

# Install node.js
RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install nodejs

# Install yarn
RUN apt-get update && apt-get install -y curl apt-transport-https wget && \
    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
    apt-get update && apt-get install -y yarn
```
使用していたyarnとnodeの分離(可読性を上げるため。)

gemfile
```
#hamlの導入
gem 'haml-rails', '1.0.0'
```
hamlのversion指定を行った。
なぜかhamlのversion指定を行わずに実行すると、haml-rails のversion3.0(存在しないバージョンが実行され、エラーが発生する。)
https://rubygems.org/gems/haml-rails/versions/2.0.0
最新バージョンは、2.0.0だが、今まで使用していたものが、1.0.0だったため、そちらを指定している。

## 動作確認項目

- docker-compose buildが成功するか　完了
- localhost:3000 がきちんと動作するか　完了

## レビュアーへのコメント(見て欲しいポイント、注意点など)

自分の環境で動作確認項目を行って、確認してほしい。