### PR TITLE
Connect sequel pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ mysql> show databases;
 ```
 ここでmercariのDBの操作を行うことが可能。
 
+また、Sequel proでの閲覧も可能(docker-compose upした状態)
+sequel proで以下を設定する。
+```
+標準を選択
+
+名前: mercari_localhost
+ホスト: 127.0.0.1
+ユーザー名: root
+パスワード: mercari_umeda
+ポート: 4306
+```
+で接続する。
+
 ### docker環境でRSpecを実行する
 ```
 1.  docker-compose run web bundle exec rake db:migrate RAILS_ENV=test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       LANG: C.UTF-8
       LANGUAGE: en_US
     ports:
-      - "3306:3306" # ホストからゲストへポートフォワード
+      - "4306:3306" # ホストからゲストへポートフォワード
     volumes:
       - mysql_data:/var/lib/mysql # MysqlDBの永続化
   web:


### PR DESCRIPTION
## チェックポイント

- [x] 開発環境で動作を確認した。
- [ ] わかりにくいと思われる箇所にコメントを書いた。

## issue番号

特になし

## 概要

Databaseをsequel proでも閲覧できるようにReadme編集

## UI変更点

特になし

## 実装内容

docker-compose.yml
database内のportを3306から4306に変更

## 動作確認項目

- sequel proで動作できるかどうかの確認　完了

## レビュアーへのコメント(見て欲しいポイント、注意点など)